### PR TITLE
Fix throwing exception when we plays this mod in languages other than English

### DIFF
--- a/InhabitantChess/Util/Translations.cs
+++ b/InhabitantChess/Util/Translations.cs
@@ -61,7 +61,7 @@ namespace InhabitantChess.Util
             Dictionary<int, string> table = TextTranslation.Get().m_table.theUITable;
             _language = TextTranslation.Get().m_language;
 
-            string transText = _transDict[_language][text.ToUpper()];
+            string transText = _transDict.ContainsKey(_language) ? _transDict[_language][text.ToUpper()] : _transDict[TextTranslation.Language.ENGLISH][text.ToUpper()];
 
             int key = table.Keys.Max() + 1;
             try


### PR DESCRIPTION
This mod throws exception and does not work if we plays in not English (like Japanese).

It is caused by not existing key in the dictionary, so I fixed it.

Thanks.