### PR TITLE
Add japanese translation (along with adding missing lines of json)

### DIFF
--- a/Assets/Translations/ic_english.json
+++ b/Assets/Translations/ic_english.json
@@ -1,5 +1,7 @@
 {
     "IC_INTERACT": "Interact",
+    "IC_NOINTERACT": "Can't interact: holding lantern!",
+    "IC_SCORE" : "Score:",
     "IC_BOARDMOVE": "Select Move",
     "IC_OVERHEAD": "Toggle Overhead",
     "IC_LEAN": "Lean Forward/Back",

--- a/Assets/Translations/ic_japanese.json
+++ b/Assets/Translations/ic_japanese.json
@@ -1,0 +1,14 @@
+{
+    "IC_INTERACT": "始める",
+    "IC_NOINTERACT": "始められない:ランタンを持っている！",
+    "IC_SCORE" : "スコア:",
+    "IC_BOARDMOVE": "移動先を選択",
+    "IC_OVERHEAD": "視点の切り替え",
+    "IC_LEAN": "前傾/後傾",
+    "IC_SILENCE": "…",
+    "IC_WAIT": "待って！",
+    "IC_JK": "いや…何でもない。",
+    "IC_DONE": "もう遊び終わったと思う。",
+    "IC_SHORTCUT": "ショートカット",
+    "IC_PLAYAGAIN": "もう一度遊ぶ"
+}


### PR DESCRIPTION
Add Japanese translation.

I noticed that `ic_english.json` on this GitHub repository has missing lines compared to one contained in your released zip file.
So, I add them into these json files, too.

Thanks.