### PR TITLE
Reflect the score when the game is finished

### DIFF
--- a/InhabitantChess/InhabitantChess.cs
+++ b/InhabitantChess/InhabitantChess.cs
@@ -293,6 +293,9 @@ namespace InhabitantChess
                 if (!_bgController.Playing)
                 {
                     _seatInteract.ChangePrompt((UITextType)Translations.GetUITextType("IC_PLAYAGAIN"));
+
+                    (int won, int lost) score = _bgController.GetScore();
+                    _screenPrompts.SetScore(score.won, score.lost);
                 }
             }
             if (PlayerState != ChessPlayerState.EnteringOverhead)


### PR DESCRIPTION
Now, the score is not reflected at the time when we finishes the game because the score is changed in only doing the interaction.

So, this PR changes to reflect it instantly when finishing the game.

Thanks.